### PR TITLE
#36 album modal UI

### DIFF
--- a/public/images/svg/album-modal-logo.svg
+++ b/public/images/svg/album-modal-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M0 0V24H9L6.3 0H0Z" fill="white"/>
+  <path d="M24 24L24 0L8.3 -1.37254e-06L11 24L24 24Z" fill="white"/>
+</svg>

--- a/public/images/svg/search.svg
+++ b/public/images/svg/search.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15" fill="none">
+  <circle cx="6" cy="6" r="5.5" stroke="white"/>
+  <path d="M10 10L14 14" stroke="white"/>
+</svg>

--- a/src/app/api/createAlbum/route.ts
+++ b/src/app/api/createAlbum/route.ts
@@ -15,7 +15,6 @@ export async function POST(request: Request) {
       },
     }
   );
-  console.log(res);
 
   return res;
 }

--- a/src/assets/mockData.ts
+++ b/src/assets/mockData.ts
@@ -171,3 +171,27 @@ export const albumMockDataList = [
     },
   ],
 ];
+
+export const mockMembersList = [
+  { name: "김기하나", profileImg: "/", owner: true, isStandBy: false },
+  { name: "김기둘", profileImg: "/", owner: false, isStandBy: false },
+  { name: "김기넷", profileImg: "/", owner: false, isStandBy: false },
+  { name: "김기셋", profileImg: "/", owner: false, isStandBy: false },
+  { name: "김기다섯", profileImg: "/", owner: false, isStandBy: false },
+  { name: "열라면요리사", profileImg: "/", owner: false, isStandBy: false },
+  { name: "박종호", profileImg: "/", owner: false, isStandBy: true },
+  { name: "문예린", profileImg: "/", owner: false, isStandBy: true },
+  { name: "비버", profileImg: "/", owner: false, isStandBy: true },
+];
+
+export const mockFriendsList = [
+  { name: "김기하나", profileImg: "/" },
+  { name: "김기둘", profileImg: "/" },
+  { name: "김기넷", profileImg: "/" },
+  { name: "김기셋", profileImg: "/" },
+  { name: "김기다섯", profileImg: "/" },
+  { name: "열라면요리사", profileImg: "/" },
+  { name: "박종호", profileImg: "/" },
+  { name: "문예린", profileImg: "/" },
+  { name: "비버", profileImg: "/" },
+];

--- a/src/templates/AddAlbumSection/index.tsx
+++ b/src/templates/AddAlbumSection/index.tsx
@@ -7,7 +7,7 @@ const AddAlbumSection = () => {
   return (
     <div
       className="w-[550px] h-[350px] border-[1px] border-white 
-    py-[23px] px-[30px] bg-main_black "
+    py-[23px] px-[30px] bg-main_black"
     >
       <div className="flex items-center gap-[6px] mb-[97px]">
         <Image src={PlusIcon} alt="추가 아이콘" width={24} height={24} />

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 import Image from "next/image";
 import RouteTrapezoidIcon from "../../../public/images/svg/route-trapezoid.svg";
 import AlbumLogoIcon from "../../../public/images/svg/album-logo.svg";
+import ModalSection from "./ModalSection";
+import TypeInfo from "./ModalSection/TypeInfo";
+import TypeMembers from "./ModalSection/TypeMembers";
 
 interface InfoPropType {
   page: number;
@@ -17,13 +20,15 @@ const AlbumInfo = ({ page, movePrevPage, moveNextPage }: InfoPropType) => {
         <div className="grow ml-[11px] text-[20px]">
           {"제목이 들어갈 자리입니다"}
         </div>
-        <div className="flex mr-[61px]">
-          <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
-          <p className="ml-[3px]">정보</p>
+        <div className="mr-[61px]">
+          <ModalSection>
+            <TypeInfo />
+          </ModalSection>
         </div>
-        <div className="flex mr-[47px]">
-          <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
-          <p className="ml-[3px]">구성원</p>
+        <div className="mr-[47px]">
+          <ModalSection>
+            <TypeMembers />
+          </ModalSection>
         </div>
         <div className="flex">
           <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -7,19 +7,23 @@ import TypeInfo from "./ModalSection/TypeInfo";
 import TypeMembers from "./ModalSection/TypeMembers";
 
 interface InfoPropType {
+  title: string;
   page: number;
   movePrevPage: () => void;
   moveNextPage: () => void;
 }
 
-const AlbumInfo = ({ page, movePrevPage, moveNextPage }: InfoPropType) => {
+const AlbumInfo = ({
+  title,
+  page,
+  movePrevPage,
+  moveNextPage,
+}: InfoPropType) => {
   return (
     <>
       <header className="h-[80px] flex items-center">
         <Image src={AlbumLogoIcon} alt="앨범 로고 아이콘" />
-        <div className="grow ml-[11px] text-[20px]">
-          {"제목이 들어갈 자리입니다"}
-        </div>
+        <div className="grow ml-[11px] text-[20px]">{title}</div>
         <div className="mr-[61px]">
           <ModalSection type="정보">
             <TypeInfo />

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -21,12 +21,12 @@ const AlbumInfo = ({ page, movePrevPage, moveNextPage }: InfoPropType) => {
           {"제목이 들어갈 자리입니다"}
         </div>
         <div className="mr-[61px]">
-          <ModalSection>
+          <ModalSection type="정보">
             <TypeInfo />
           </ModalSection>
         </div>
         <div className="mr-[47px]">
-          <ModalSection>
+          <ModalSection type="구성원">
             <TypeMembers />
           </ModalSection>
         </div>

--- a/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
@@ -1,0 +1,4 @@
+const TypeInfo = () => {
+  return <div>hello</div>;
+};
+export default TypeInfo;

--- a/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
@@ -1,4 +1,59 @@
+import Image from "next/image";
+import Trapezoid from "@/components/Trapezoid";
+
+const mockThumbnailImage = "/images/park.jpeg";
+
 const TypeInfo = () => {
-  return <div>hello</div>;
+  return (
+    <section className="flex pl-[10px] pr-[13px] h-[330px]">
+      <div className="grow">
+        <p className=" text-[18px] mb-[10px]">조각보 표지</p>
+        <div className="flex gap-[25px]">
+          <Trapezoid
+            styles={{
+              width: "80px",
+              height: "200px",
+              clipPath: "polygon(0% 0%, 75% 0%, 100% 100%, 0% 100%)",
+              position: "relative",
+            }}
+          >
+            <Image
+              src={mockThumbnailImage}
+              alt="thumbnail"
+              fill
+              style={{ objectFit: "cover", objectPosition: "center" }}
+            />
+          </Trapezoid>
+          <div className="w-[150px] h-[200px] bg-white"></div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-[36px]">
+        <div>
+          <p className="text-[18px] mb-[3px]">조각보 이름</p>
+          <input
+            disabled
+            value="조각보 이름"
+            className="w-[172px] h-[50px] bg-main_black outline-none border-b-[1px] border-white text-[14px] text-center"
+          />
+        </div>
+        <div>
+          <p className="text-[18px] mb-[3px]">조각보 제작 날짜</p>
+          <input
+            disabled
+            value="2023.10.04"
+            className="w-[172px] h-[50px] bg-main_black outline-none border-b-[1px] border-white text-[14px] text-center"
+          />
+        </div>
+        <div>
+          <p className="text-[18px] mb-[3px]">공개 여부</p>
+          <input
+            disabled
+            value="전체 공개"
+            className="w-[172px] h-[50px] bg-main_black outline-none border-b-[1px] border-white text-[14px] text-center"
+          />
+        </div>
+      </div>
+    </section>
+  );
 };
 export default TypeInfo;

--- a/src/templates/AlbumSection/ModalSection/TypeMembers.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeMembers.tsx
@@ -1,4 +1,78 @@
+import Image from "next/image";
+import Trapezoid from "@/components/Trapezoid";
+import SearchIcon from "../../../../public/images/svg/search.svg";
+import { mockMembersList, mockFriendsList } from "@/assets/mockData";
+
 const TypeMembers = () => {
-  return <div>hello</div>;
+  return (
+    <section className="flex pl-[10px] h-[330px] gap-[25px]">
+      <div className="w-[510px]">
+        <div className="flex mb-[28px]">
+          <p className="text-[18px] grow">구성원 목록</p>
+          <div className="relative">
+            <Image
+              src={SearchIcon}
+              alt="검색"
+              className="absolute top-[7px] left-[2px]"
+              width={14}
+              height={14}
+            />
+            <input
+              placeholder="구성원 검색"
+              className="w-[140px] pl-[20px] pb-[5px] bg-main_black 
+            outline-none border-b-[1px] border-white box-border text-[12px]"
+            />
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-x-[37px] gap-y-[20px]">
+          {mockMembersList.map((item, index) => (
+            <div key={index} className={`${item.isStandBy && "opacity-30"}`}>
+              <Trapezoid
+                styles={{
+                  width: "70px",
+                  height: "70px",
+                  clipPath: "polygon(0 0, 100% 0, 100% 90%, 0 100%)",
+                  position: "relative",
+                  bgColor: "white",
+                }}
+              >
+                {item.owner && (
+                  <p className="text-main_black text-[10px] pt-[2px] pl-[4px]">
+                    주인장
+                  </p>
+                )}
+                {item.isStandBy && (
+                  <p className="text-main_black text-[10px] pt-[2px] pl-[4px]">
+                    초대됨
+                  </p>
+                )}
+              </Trapezoid>
+              <p className="text-[14px] pt-[10px]">{item.name}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="grow">
+        <p className="text-[18px] mb-[28px]">구성원 초대</p>
+        <div className="h-[250px] overflow-scroll">
+          {mockFriendsList.map((item, index) => (
+            <div key={index} className="flex items-center mb-[20px]">
+              <Trapezoid
+                styles={{
+                  width: "40px",
+                  height: "40px",
+                  clipPath: "polygon(0 0, 100% 0, 100% 90%, 0 100%)",
+                  position: "relative",
+                  bgColor: "white",
+                }}
+              />
+              <p className="ml-[10px] grow text-[14px]">{item.name}</p>
+              <p className="underline text-[14px] cursor-pointer">초대</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 };
 export default TypeMembers;

--- a/src/templates/AlbumSection/ModalSection/TypeMembers.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeMembers.tsx
@@ -1,0 +1,4 @@
+const TypeMembers = () => {
+  return <div>hello</div>;
+};
+export default TypeMembers;

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
 import RouteTrapezoidIcon from "../../../../public/images/svg/route-trapezoid.svg";
 import ModalLogoIcon from "../../../../public/images/svg/album-modal-logo.svg";
+import Trapezoid from "@/components/Trapezoid";
 
 interface ModalProps {
   children: React.ReactNode;
@@ -15,8 +16,8 @@ const AlbumModal = ({ children, type }: ModalProps) => {
         <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
         <p>{type}</p>
       </Dialog.Trigger>
-      <Dialog.Overlay className="fixed inset-0 bg-black/70" />
-      <Dialog.DialogContent className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+      <Dialog.Overlay className="fixed z-30 inset-0 bg-black/70" />
+      <Dialog.DialogContent className="z-30 fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
         <div
           className="w-[800px] h-[500px] bg-main_black border-[1px] border-white 
         pt-[23px] pl-[30px] pr-[40px]"
@@ -26,7 +27,20 @@ const AlbumModal = ({ children, type }: ModalProps) => {
             <p className="font-semibold text-[20px]">조각보 {type}</p>
           </header>
           {children}
-          <Dialog.Close>닫기</Dialog.Close>
+          <footer className="flex justify-center pt-[20px]">
+            <Dialog.Close>
+              <Trapezoid
+                styles={{
+                  width: "75px",
+                  height: "30px",
+                  clipPath: "polygon(0% 0%, 100% 25%, 100% 100%, 0% 100%)",
+                  bgColor: "white",
+                }}
+              >
+                <p className="text-main_black pt-[4px]">닫기</p>
+              </Trapezoid>
+            </Dialog.Close>
+          </footer>
         </div>
       </Dialog.DialogContent>
     </Dialog.Root>

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -4,19 +4,26 @@ import RouteTrapezoidIcon from "../../../../public/images/svg/route-trapezoid.sv
 
 interface ModalProps {
   children: React.ReactNode;
+  type: string;
 }
 
-const AlbumModal = ({ children }: ModalProps) => {
+const AlbumModal = ({ children, type }: ModalProps) => {
   return (
     <Dialog.Root>
       <Dialog.Trigger className="flex gap-[3px]">
         <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
-        <p>정보</p>
+        <p>{type}</p>
       </Dialog.Trigger>
       <Dialog.Overlay className="fixed inset-0 bg-black/70" />
       <Dialog.DialogContent className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-        {children}
-        <Dialog.Close>닫기</Dialog.Close>
+        <div
+          className="w-[800px] h-[500px] bg-main_black border-[1px] border-white 
+        pt-[23px] pl-[30px] pr-[40px]"
+        >
+          <header className="font-semibold text-[20px]">조각보 {type}</header>
+          {children}
+          <Dialog.Close>닫기</Dialog.Close>
+        </div>
       </Dialog.DialogContent>
     </Dialog.Root>
   );

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+import * as Dialog from "@radix-ui/react-dialog";
+import RouteTrapezoidIcon from "../../../../public/images/svg/route-trapezoid.svg";
+
+interface ModalProps {
+  children: React.ReactNode;
+}
+
+const AlbumModal = ({ children }: ModalProps) => {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger className="flex gap-[3px]">
+        <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
+        <p>정보</p>
+      </Dialog.Trigger>
+      <Dialog.Overlay className="fixed inset-0 bg-black/70" />
+      <Dialog.DialogContent className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        {children}
+        <Dialog.Close>닫기</Dialog.Close>
+      </Dialog.DialogContent>
+    </Dialog.Root>
+  );
+};
+
+export default AlbumModal;

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
 import RouteTrapezoidIcon from "../../../../public/images/svg/route-trapezoid.svg";
+import ModalLogoIcon from "../../../../public/images/svg/album-modal-logo.svg";
 
 interface ModalProps {
   children: React.ReactNode;
@@ -20,7 +21,10 @@ const AlbumModal = ({ children, type }: ModalProps) => {
           className="w-[800px] h-[500px] bg-main_black border-[1px] border-white 
         pt-[23px] pl-[30px] pr-[40px]"
         >
-          <header className="font-semibold text-[20px]">조각보 {type}</header>
+          <header className="flex gap-[6px] pb-[42px]">
+            <Image src={ModalLogoIcon} alt="로고" />
+            <p className="font-semibold text-[20px]">조각보 {type}</p>
+          </header>
           {children}
           <Dialog.Close>닫기</Dialog.Close>
         </div>

--- a/src/templates/AlbumSection/index.tsx
+++ b/src/templates/AlbumSection/index.tsx
@@ -11,6 +11,7 @@ import { parsingImagesSize } from "@/lib/getImgValue";
 
 const AlbumSection = ({ params }: { params: { id: string } }) => {
   const [page, setPage] = useState<number>(0);
+  const [albumTitle, setAlbumTitle] = useState<string>("");
   const [albumBodyData, setAlbumBodyData] = useState<ImageType[][]>([]);
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
   const stageRef = useRef<Konva.Stage>(null);
@@ -31,6 +32,7 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
         }
       );
       const data = await res.json();
+      setAlbumTitle(data.albumName);
       setAlbumBodyData(data.imagesInfo);
     }
     getInitData();
@@ -181,6 +183,7 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
     <section className="relative pb-[80px]">
       <AlbumInfo
         page={page}
+        title={albumTitle}
         movePrevPage={() => {
           setSelectedImageId(null);
           setPage((prev) => prev - 1);

--- a/src/templates/AlbumSection/index.tsx
+++ b/src/templates/AlbumSection/index.tsx
@@ -20,6 +20,20 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
 
   useEffect(() => {
     let accessToken = session?.jogakTokens.accessToken;
+    async function getInitData() {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/album?albumID=${params.id}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+      const data = await res.json();
+      setAlbumBodyData(data.imagesInfo);
+    }
+    getInitData();
     client.current = new Client({
       brokerURL: `ws://${process.env.NEXT_PUBLIC_SOCKET_SERVER_URL}/album-ws`,
       connectHeaders: {
@@ -40,7 +54,7 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
       client.current.deactivate();
     };
   }, [session, params.id]);
-  console.log(params.id);
+
   useEffect(() => {
     const stage = stageRef.current?.getStage();
     const pushData = async (data: any, formData: any) => {


### PR DESCRIPTION
## 앨범 페이지에 있는 모달 UI 구현
- 모달의 header와 footer등 공통 부분 구현 후 컴포넌트 재활용
- api 미구현 및 UI의 미확정으로 mock data로 구현

## 앨범 입장 시 api 구현
- 입장 시 앨범 정보와 이미지를 불러오는 api 연결, 앨범 생성 및 재 입장 시 데이터 불러오기 가능