### PR TITLE
#80 album page UI edit

### DIFF
--- a/public/images/svg/info.svg
+++ b/public/images/svg/info.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_761_1126)">
+    <path d="M14 8L15 24L8 24L9 8L14 8Z" fill="white"/>
+    <path d="M14 6L15 -9.53674e-07L9 -1.00137e-06L9 6L14 6Z" fill="white"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_761_1126">
+      <rect width="24" height="24" fill="white"/>
+    </clipPath>
+  </defs> 
+</svg>

--- a/public/images/svg/next.svg
+++ b/public/images/svg/next.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 23V1L20 12L8 23Z" fill="white"/>
+</svg>

--- a/public/images/svg/next_disabled.svg
+++ b/public/images/svg/next_disabled.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 23V1L20 12L8 23Z" fill="#888"/>
+</svg>

--- a/public/images/svg/next_plus.svg
+++ b/public/images/svg/next_plus.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="24" viewBox="0 0 40 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 23V1L20 12L8 23Z" fill="white"/>
+  <path d="M33.4375 7V17H37.1875L36.0625 7H33.4375Z" fill="white"/>
+  <path d="M40 10.4375L30 10.4375L30 14.1875L40 13.0625L40 10.4375Z" fill="white"/>
+</svg>

--- a/public/images/svg/prev.svg
+++ b/public/images/svg/prev.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M16 23V1L4 12L16 23Z" fill="white"/>
+</svg>

--- a/public/images/svg/prev_disabled.svg
+++ b/public/images/svg/prev_disabled.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M16 23V1L4 12L16 23Z" fill="#888"/>
+</svg>

--- a/src/app/(makeupAlbum)/album/[id]/error.tsx
+++ b/src/app/(makeupAlbum)/album/[id]/error.tsx
@@ -8,9 +8,19 @@ const Error = () => {
     <section className="w-full h-[100vh] flex flex-col justify-center items-center gap-[35px]">
       <Image src={ErrorLogo} alt="에러" />
       <p className="text-[20px]">유효하지 않은 접근입니다.</p>
-      <Link href="/my" className="underline text-[20px]">
-        홈
-      </Link>
+      <div className="flex gap-[10px]">
+        <Link href="/my" className="underline text-[14px]">
+          홈
+        </Link>
+        <p
+          className="underline text-[14px] cursor-pointer"
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          새로고침
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/components/HoverText.tsx
+++ b/src/components/HoverText.tsx
@@ -11,5 +11,3 @@ const HoverText = ({ children }: HoverTextProps) => {
 };
 
 export default HoverText;
-
-// left-[50%] translate-x-[-50%]

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -133,23 +133,25 @@ const AlbumInfo = ({
           {isHoverIcon && <HoverText>내 조각보</HoverText>}
         </div>
       </header>
-      <button
-        className="absolute left-[-50px] top-[410px]"
-        disabled={page <= 0}
-        onClick={movePrevPage}
+      <section
+        className="absolute top-[913px] left-[50%] translate-x-[-50%]
+        flex items-center"
       >
-        <Image src={page <= 0 ? PrevDisabledIcon : PrevIcon} alt="이전" />
-      </button>
-
-      <button
-        className="absolute right-[-50px] top-[410px]"
-        onClick={() => moveNextPage(page + 1 === albumSize)}
-      >
-        <Image
-          src={page + 1 === albumSize ? NextDisabledIcon : NextIcon}
-          alt="다음"
-        />
-      </button>
+        <button disabled={page <= 0} onClick={movePrevPage}>
+          <Image src={page <= 0 ? PrevDisabledIcon : PrevIcon} alt="이전" />
+        </button>
+        <p className="text-white mx-[66px]">
+          <span className="mr-[20px]">{page + 1}</span>
+          <span>/</span>
+          <span className="ml-[20px]">{albumSize}</span>
+        </p>
+        <button onClick={() => moveNextPage(page + 1 === albumSize)}>
+          <Image
+            src={page + 1 === albumSize ? NextDisabledIcon : NextIcon}
+            alt="다음"
+          />
+        </button>
+      </section>
     </>
   );
 };

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -40,6 +40,7 @@ const AlbumInfo = ({
   const [imageFile, setImageFile] = useState<any>();
   const { isHoverIcon, handleIsHoverToFalse, handleIsHoverToTrue } =
     useHoverText();
+
   const toggleEditStat = () => {
     setIsEditStat((prev) => !prev);
     setAlbumInfo((prev: any) => {

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -3,10 +3,6 @@ import Link from "next/link";
 import Image from "next/image";
 import AlbumLogoIcon from "../../../public/images/svg/album-logo.svg";
 import MyJogakboIcon from "../../../public/images/svg/my-jogakbo.svg";
-import PrevIcon from "../../../public/images/svg/prev.svg";
-import PrevDisabledIcon from "../../../public/images/svg/prev_disabled.svg";
-import NextIcon from "../../../public/images/svg/next.svg";
-import NextDisabledIcon from "../../../public/images/svg/next_disabled.svg";
 import ModalSection from "./ModalSection";
 import TypeInfo from "./ModalSection/TypeInfo";
 import TypeMembers from "./ModalSection/TypeMembers";
@@ -22,10 +18,6 @@ interface InfoPropType {
   albumID: string;
   title: string;
   thumbnail: any;
-  page: number;
-  albumSize: number;
-  movePrevPage: () => void;
-  moveNextPage: (isCreate: boolean) => void;
   setAlbumInfo: any;
 }
 
@@ -34,10 +26,6 @@ const AlbumInfo = ({
   albumID,
   title,
   thumbnail,
-  page,
-  albumSize,
-  movePrevPage,
-  moveNextPage,
   setAlbumInfo,
 }: InfoPropType) => {
   const [isEditStat, setIsEditStat] = useState<boolean>(false);
@@ -133,25 +121,6 @@ const AlbumInfo = ({
           {isHoverIcon && <HoverText>내 조각보</HoverText>}
         </div>
       </header>
-      <section
-        className="absolute top-[913px] left-[50%] translate-x-[-50%]
-        flex items-center"
-      >
-        <button disabled={page <= 0} onClick={movePrevPage}>
-          <Image src={page <= 0 ? PrevDisabledIcon : PrevIcon} alt="이전" />
-        </button>
-        <p className="text-white mx-[66px]">
-          <span className="mr-[20px]">{page + 1}</span>
-          <span>/</span>
-          <span className="ml-[20px]">{albumSize}</span>
-        </p>
-        <button onClick={() => moveNextPage(page + 1 === albumSize)}>
-          <Image
-            src={page + 1 === albumSize ? NextDisabledIcon : NextIcon}
-            alt="다음"
-          />
-        </button>
-      </section>
     </>
   );
 };

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -3,6 +3,10 @@ import Link from "next/link";
 import Image from "next/image";
 import AlbumLogoIcon from "../../../public/images/svg/album-logo.svg";
 import MyJogakboIcon from "../../../public/images/svg/my-jogakbo.svg";
+import PrevIcon from "../../../public/images/svg/prev.svg";
+import PrevDisabledIcon from "../../../public/images/svg/prev_disabled.svg";
+import NextIcon from "../../../public/images/svg/next.svg";
+import NextDisabledIcon from "../../../public/images/svg/next_disabled.svg";
 import ModalSection from "./ModalSection";
 import TypeInfo from "./ModalSection/TypeInfo";
 import TypeMembers from "./ModalSection/TypeMembers";
@@ -130,29 +134,22 @@ const AlbumInfo = ({
         </div>
       </header>
       <button
-        className={`absolute left-[-50px] top-[410px] ${
-          page > 0 && "hover:cursor-pointer"
-        } ${page <= 0 && "text-red-500"}`}
+        className="absolute left-[-50px] top-[410px]"
         disabled={page <= 0}
         onClick={movePrevPage}
       >
-        이전
+        <Image src={page <= 0 ? PrevDisabledIcon : PrevIcon} alt="이전" />
       </button>
-      {page + 1 === albumSize ? (
-        <button
-          className="absolute right-[-50px] top-[410px] hover:cursor-pointer"
-          onClick={() => moveNextPage(true)}
-        >
-          생성
-        </button>
-      ) : (
-        <button
-          className="absolute right-[-50px] top-[410px] hover:cursor-pointer"
-          onClick={() => moveNextPage(false)}
-        >
-          다음
-        </button>
-      )}
+
+      <button
+        className="absolute right-[-50px] top-[410px]"
+        onClick={() => moveNextPage(page + 1 === albumSize)}
+      >
+        <Image
+          src={page + 1 === albumSize ? NextDisabledIcon : NextIcon}
+          alt="다음"
+        />
+      </button>
     </>
   );
 };

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -6,6 +6,8 @@ import MyJogakboIcon from "../../../public/images/svg/my-jogakbo.svg";
 import ModalSection from "./ModalSection";
 import TypeInfo from "./ModalSection/TypeInfo";
 import TypeMembers from "./ModalSection/TypeMembers";
+import useHoverText from "@/hooks/useHoverText";
+import HoverText from "@/components/HoverText";
 
 interface InfoPropType {
   info: {
@@ -36,7 +38,8 @@ const AlbumInfo = ({
 }: InfoPropType) => {
   const [isEditStat, setIsEditStat] = useState<boolean>(false);
   const [imageFile, setImageFile] = useState<any>();
-
+  const { isHoverIcon, handleIsHoverToFalse, handleIsHoverToTrue } =
+    useHoverText();
   const toggleEditStat = () => {
     setIsEditStat((prev) => !prev);
     setAlbumInfo((prev: any) => {
@@ -114,10 +117,15 @@ const AlbumInfo = ({
             <TypeMembers />
           </ModalSection>
         </div>
-        <div className="flex">
-          <Link href="/" className="ml-[3px]">
+        <div className="relative whitespace-nowrap">
+          <Link
+            href="/"
+            onMouseOver={handleIsHoverToTrue}
+            onMouseLeave={handleIsHoverToFalse}
+          >
             <Image src={MyJogakboIcon} alt="내 조각보 아이콘" />
           </Link>
+          {isHoverIcon && <HoverText>내 조각보</HoverText>}
         </div>
       </header>
       <button

--- a/src/templates/AlbumSection/AlbumInfo.tsx
+++ b/src/templates/AlbumSection/AlbumInfo.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import RouteTrapezoidIcon from "../../../public/images/svg/route-trapezoid.svg";
 import AlbumLogoIcon from "../../../public/images/svg/album-logo.svg";
+import MyJogakboIcon from "../../../public/images/svg/my-jogakbo.svg";
 import ModalSection from "./ModalSection";
 import TypeInfo from "./ModalSection/TypeInfo";
 import TypeMembers from "./ModalSection/TypeMembers";
@@ -92,7 +92,7 @@ const AlbumInfo = ({
       <header className="h-[80px] flex items-center">
         <Image src={AlbumLogoIcon} alt="앨범 로고 아이콘" />
         <div className="grow ml-[11px] text-[20px]">{title}</div>
-        <div className="mr-[61px]">
+        <div className="mr-[30px]">
           <ModalSection
             type="정보"
             isEditStat={isEditStat}
@@ -109,15 +109,14 @@ const AlbumInfo = ({
             />
           </ModalSection>
         </div>
-        <div className="mr-[47px]">
+        <div className="mr-[30px]">
           <ModalSection type="구성원">
             <TypeMembers />
           </ModalSection>
         </div>
         <div className="flex">
-          <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
           <Link href="/" className="ml-[3px]">
-            내 조각보
+            <Image src={MyJogakboIcon} alt="내 조각보 아이콘" />
           </Link>
         </div>
       </header>

--- a/src/templates/AlbumSection/ImagesByPage.tsx
+++ b/src/templates/AlbumSection/ImagesByPage.tsx
@@ -38,7 +38,7 @@ const ImagesByPage = ({
   onChangeAttrs,
 }: ImageByPagePropsType) => {
   const [image] = useImage(
-    `${process.env.NEXT_PUBLIC_S3_URL}${imageInfo.imageUUID}`
+    `${process.env.NEXT_PUBLIC_S3_URL}${albumID}/${imageInfo.imageUUID}`
   );
   const imageRef = useRef<any>(null);
   const trRef = useRef<Konva.Transformer>(null);

--- a/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Trapezoid } from "@/components/Trapezoid";
 
 interface TypeInfoPropsType {
   info: {
@@ -39,8 +40,8 @@ const TypeInfo = ({
             onMouseOver={() => setIsHoverProfile(true)}
             onMouseLeave={() => setIsHoverProfile(false)}
             className="relative w-[112px] h-[280px] bg-white 
-          [clipPath:polygon(0%_0%,75%_0%,100%_100%,0%_100%)]
-          bg-cover bg-center border-[1px] border-white
+              [clipPath:polygon(0%_0%,75%_0%,100%_100%,0%_100%)]
+              bg-cover bg-center
            "
             style={{
               backgroundImage: `${
@@ -52,6 +53,22 @@ const TypeInfo = ({
               }`,
             }}
           >
+            <Trapezoid
+              styles={{
+                width: "112px",
+                height: "280px",
+                clipPath: "polygon(0 0, 75% 0%, 100% 100%, 0% 100%)",
+                bgColor: "rgba(21,21,21,0.3)",
+                position: "absolute",
+                zIndex: 10,
+              }}
+            />
+            <p
+              className="rotate-90 font-semibold text-[28px] w-[280px] origin-top-left absolute top-[24px]
+                left-[56px] z-30"
+            >
+              {info.albumName}
+            </p>
             <input
               id="uploadImg"
               type="file"

--- a/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
@@ -22,7 +22,6 @@ const TypeInfo = ({
   albumID,
   upLoadImage,
 }: TypeInfoPropsType) => {
-  const [isHoverProfile, setIsHoverProfile] = useState<boolean>(false);
   const { createdDate } = info;
   const createdDateFormat =
     createdDate.slice(0, 4) +
@@ -34,11 +33,23 @@ const TypeInfo = ({
   return (
     <section className="flex h-[330px]">
       <div className="grow">
-        <p className=" text-[18px] mb-[10px]">조각보 표지</p>
+        <div className="flex gap-[9px] items-center mb-[10px]">
+          <p className="text-[18px]">조각보 표지</p>
+          <input
+            id="uploadImg"
+            type="file"
+            accept="image/*"
+            onChange={upLoadImage}
+            className="hidden"
+          />
+          {isEditStat && (
+            <label htmlFor="uploadImg" className="cursor-pointer underline">
+              <p className="text-[14px]">수정</p>
+            </label>
+          )}
+        </div>
         <div className="flex gap-[25px]">
           <div
-            onMouseOver={() => setIsHoverProfile(true)}
-            onMouseLeave={() => setIsHoverProfile(false)}
             className="relative w-[112px] h-[280px] bg-white 
               [clipPath:polygon(0%_0%,75%_0%,100%_100%,0%_100%)]
               bg-cover bg-center
@@ -64,27 +75,11 @@ const TypeInfo = ({
               }}
             />
             <p
-              className="rotate-90 font-semibold text-[28px] w-[280px] origin-top-left absolute top-[24px]
-                left-[56px] z-30"
+              className="absolute rotate-90 font-semibold text-[24px] w-[280px] origin-top-left top-[30px]
+                left-[50px] z-30"
             >
               {info.albumName}
             </p>
-            <input
-              id="uploadImg"
-              type="file"
-              accept="image/*"
-              onChange={upLoadImage}
-              className="hidden"
-            />
-            {isHoverProfile && isEditStat && (
-              <label
-                htmlFor="uploadImg"
-                className="z-30 bg-main_black_opacity cursor-pointer 
-                w-full h-full flex justify-center items-center"
-              >
-                <p className="text-[20px] font-semibold">수정</p>
-              </label>
-            )}
           </div>
         </div>
       </div>

--- a/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
+++ b/src/templates/AlbumSection/ModalSection/TypeInfo.tsx
@@ -48,7 +48,7 @@ const TypeInfo = ({
             </label>
           )}
         </div>
-        <div className="flex gap-[25px]">
+        <div className="flex gap-[60px]">
           <div
             className="relative w-[112px] h-[280px] bg-white 
               [clipPath:polygon(0%_0%,75%_0%,100%_100%,0%_100%)]
@@ -81,6 +81,18 @@ const TypeInfo = ({
               {info.albumName}
             </p>
           </div>
+          <div
+            className="relative w-[200px] h-[280px] bg-white bg-cover bg-center"
+            style={{
+              backgroundImage: `${
+                thumbnail === info.thumbnailImage
+                  ? `url(${
+                      thumbnail && process.env.NEXT_PUBLIC_S3_URL
+                    }${albumID}/${info.thumbnailImage})`
+                  : `url(${info.thumbnailImage})`
+              }`,
+            }}
+          ></div>
         </div>
       </div>
       <div className="flex flex-col gap-[36px]">

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -4,6 +4,8 @@ import ModalLogoIcon from "../../../../public/images/svg/album-modal-logo.svg";
 import InfoIcon from "../../../../public/images/svg/info.svg";
 import MembersLogoIcon from "../../../../public/images/svg/members-logo.svg";
 import { TrapeButton } from "@/components/Trapezoid";
+import useHoverText from "@/hooks/useHoverText";
+import HoverText from "@/components/HoverText";
 
 interface ModalProps {
   children: React.ReactNode;
@@ -20,16 +22,26 @@ const AlbumModal = ({
   toggleEditStat,
   handleSubmitEdit,
 }: ModalProps) => {
+  const { isHoverIcon, handleIsHoverToFalse, handleIsHoverToTrue } =
+    useHoverText();
   return (
     <Dialog.Root>
-      <Dialog.Trigger className="flex gap-[3px]">
-        <p>
-          {type === "정보" ? (
+      <Dialog.Trigger
+        className="relative flex gap-[3px] whitespace-nowrap"
+        onMouseOver={handleIsHoverToTrue}
+        onMouseLeave={handleIsHoverToFalse}
+      >
+        {type === "정보" ? (
+          <>
             <Image src={InfoIcon} alt="정보 아이콘" />
-          ) : (
+            {isHoverIcon && <HoverText>정보</HoverText>}
+          </>
+        ) : (
+          <>
             <Image src={MembersLogoIcon} alt="구성원 아이콘" />
-          )}
-        </p>
+            {isHoverIcon && <HoverText>구성원</HoverText>}
+          </>
+        )}
       </Dialog.Trigger>
       <Dialog.Overlay className="fixed z-30 inset-0 bg-black/70" />
       <Dialog.DialogContent className="z-30 fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -1,7 +1,8 @@
 import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
-import RouteTrapezoidIcon from "../../../../public/images/svg/route-trapezoid.svg";
 import ModalLogoIcon from "../../../../public/images/svg/album-modal-logo.svg";
+import InfoIcon from "../../../../public/images/svg/info.svg";
+import MembersLogoIcon from "../../../../public/images/svg/members-logo.svg";
 import { TrapeButton } from "@/components/Trapezoid";
 
 interface ModalProps {
@@ -22,8 +23,13 @@ const AlbumModal = ({
   return (
     <Dialog.Root>
       <Dialog.Trigger className="flex gap-[3px]">
-        <Image src={RouteTrapezoidIcon} alt="사다리꼴 아이콘" />
-        <p>{type}</p>
+        <p>
+          {type === "정보" ? (
+            <Image src={InfoIcon} alt="정보 아이콘" />
+          ) : (
+            <Image src={MembersLogoIcon} alt="구성원 아이콘" />
+          )}
+        </p>
       </Dialog.Trigger>
       <Dialog.Overlay className="fixed z-30 inset-0 bg-black/70" />
       <Dialog.DialogContent className="z-30 fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">

--- a/src/templates/AlbumSection/ModalSection/index.tsx
+++ b/src/templates/AlbumSection/ModalSection/index.tsx
@@ -66,7 +66,7 @@ const AlbumModal = ({
             {isEditStat ? (
               <>
                 <TrapeButton type="outline" handleClick={toggleEditStat}>
-                  수정 종료
+                  취소
                 </TrapeButton>
                 <TrapeButton handleClick={handleSubmitEdit}>수정</TrapeButton>
               </>

--- a/src/templates/AlbumSection/PagiNation.tsx
+++ b/src/templates/AlbumSection/PagiNation.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import Image from "next/image";
+import PrevIcon from "../../../public/images/svg/prev.svg";
+import PrevDisabledIcon from "../../../public/images/svg/prev_disabled.svg";
+import NextIcon from "../../../public/images/svg/next.svg";
+import NextDisabledIcon from "../../../public/images/svg/next_disabled.svg";
+import PlusIcon from "../../../public/images/svg/plus.svg";
+
+interface PagiNationPropsType {
+  page: number;
+  movePrevPage: () => void;
+  moveNextPage: (isCreate: boolean) => void;
+  albumSize: number;
+}
+
+const PagiNation = ({
+  page,
+  movePrevPage,
+  moveNextPage,
+  albumSize,
+}: PagiNationPropsType) => {
+  const [isHoverPlusBtn, setIsHoverPlusBtn] = useState<boolean>(false);
+  return (
+    <div className="relative w-[180px] mt-[17px] mx-auto">
+      <button
+        disabled={page <= 0}
+        onClick={movePrevPage}
+        className="absolute left-0"
+      >
+        <Image src={page <= 0 ? PrevDisabledIcon : PrevIcon} alt="이전" />
+      </button>
+      <p className="absolute w-[65px] left-[50%] translate-x-[-50%] text-white">
+        <span className="absolute left-0">{page + 1}</span>
+        <span className="absolute left-[50%] translate-x-[-50%]">/</span>
+        <span className="absolute right-0">{albumSize}</span>
+      </p>
+      <button
+        onMouseOver={() => setIsHoverPlusBtn(true)}
+        onMouseLeave={() => setIsHoverPlusBtn(false)}
+        onClick={() => moveNextPage(page + 1 === albumSize)}
+        className="absolute right-0"
+      >
+        <Image
+          src={page + 1 === albumSize ? NextDisabledIcon : NextIcon}
+          alt="다음"
+        />
+      </button>
+      {page + 1 === albumSize && isHoverPlusBtn && (
+        <Image
+          src={PlusIcon}
+          alt="추가"
+          width={10}
+          height={10}
+          className="absolute top-[6px] right-[-15px]"
+        />
+      )}
+    </div>
+  );
+};
+
+export default PagiNation;

--- a/src/templates/AlbumSection/index.tsx
+++ b/src/templates/AlbumSection/index.tsx
@@ -10,6 +10,7 @@ import AlbumInfo from "@/templates/AlbumSection/AlbumInfo";
 import type { ImageType } from "@/types";
 import { parsingImagesSize } from "@/lib/getImgValue";
 import LoadingGIF from "@/components/LoadingGIF";
+import PagiNation from "./PagiNation";
 
 const AlbumSection = ({ params }: { params: { id: string } }) => {
   const [page, setPage] = useState<number>(0);
@@ -172,18 +173,11 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
     <section className="relative pb-[100px]">
       {isUpLoading && <LoadingGIF />}
       <AlbumInfo
-        page={page}
         albumID={params.id}
-        albumSize={albumBodyData.length}
         title={albumName}
         thumbnail={albumThumbnail}
         info={albumInfo}
         setAlbumInfo={setAlbumInfo}
-        movePrevPage={() => {
-          setSelectedImageId(null);
-          setPage((prev) => prev - 1);
-        }}
-        moveNextPage={handleNextBtnClick}
       />
       <Stage
         width={1200}
@@ -233,6 +227,15 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
           ))}
         </Layer>
       </Stage>
+      <PagiNation
+        page={page}
+        albumSize={albumBodyData.length}
+        movePrevPage={() => {
+          setSelectedImageId(null);
+          setPage((prev) => prev - 1);
+        }}
+        moveNextPage={handleNextBtnClick}
+      />
     </section>
   );
 };

--- a/src/templates/AlbumSection/index.tsx
+++ b/src/templates/AlbumSection/index.tsx
@@ -190,7 +190,7 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
         height={800}
         className={` ${isDragging && "border-[1px] border-white"} ${
           isDragging ? "bg-main_black" : "bg-[#303030]"
-        }`}
+        } ${isDragging && "opacity-50"}`}
         ref={stageRef}
         onMouseDown={(e) => imageFocus(e)}
         onTouchStart={(e) => imageFocus(e)}

--- a/src/templates/AlbumSection/index.tsx
+++ b/src/templates/AlbumSection/index.tsx
@@ -169,7 +169,7 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
     setPage((prev) => prev + 1);
   };
   return (
-    <section className="relative pb-[80px]">
+    <section className="relative pb-[100px]">
       {isUpLoading && <LoadingGIF />}
       <AlbumInfo
         page={page}
@@ -233,9 +233,6 @@ const AlbumSection = ({ params }: { params: { id: string } }) => {
           ))}
         </Layer>
       </Stage>
-      <p className="text-white text-center">
-        {page + 1}/{albumBodyData.length}
-      </p>
     </section>
   );
 };

--- a/src/templates/MainSection/AlbumList.tsx
+++ b/src/templates/MainSection/AlbumList.tsx
@@ -68,7 +68,9 @@ const AlbumList = ({ albums }: AlbumListProps) => {
                   height: "200px",
                   clipPath: SHAPE_BY_INDEX[row][column],
                   position: "relative",
-                  bgColor: THUMBNAIL_COLOR[index % 4],
+                  bgColor: item.thumbnailImage
+                    ? "white"
+                    : THUMBNAIL_COLOR[index % 4],
                 }}
               >
                 <Trapezoid

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface FriendsType {
 export interface AlbumsType {
   albumID: string;
   albumName: string;
+  thumbnailImage: string;
   images: ImageType[];
   albumEditors: any;
 }


### PR DESCRIPTION
### ISSUE

#80 

### Description

앨범 페이지 UI 수정 및 추가
- 헤더 아이콘 변경 + 아이콘 hover 시 텍스트 출력
- 앨범 정보 모달 썸네일 이미지
  - 큰 이미지 추가
  - 기존 이미지에는 메인페이지에 보이는 조각과 동일하게 수정
  - 기존 이미지 수정에 따른 수정방식 변경: 이미지 hover -> 수정버튼
- 이미지 업로드 드래그 시 투명도 추가
- 앨범 페이지네이션 UI 완성
  - 아이콘 추가
  - 다음페이지와 생성페이지 버튼 구분(색상, 플러스 아이콘)